### PR TITLE
Update nomad-acl-user.hcl

### DIFF
--- a/shared/config/nomad-acl-user.hcl
+++ b/shared/config/nomad-acl-user.hcl
@@ -1,12 +1,34 @@
-agent { 
-    policy = "read"
-} 
+agent {
+    policy = "write"
+}
 
-node { 
-    policy = "read" 
-} 
+quota {
+  policy = "write"
+}
 
-namespace "*" { 
-    policy = "read" 
-    capabilities = ["submit-job", "read-logs", "read-fs"]
+host_volume "*" {
+  policy = "write"
+}
+
+node_pool "*" {
+  policy       = "write"
+  #capabilities = ["write"]
+}
+
+plugin {
+  policy = "write"
+}
+
+node {
+    policy = "write"
+}
+
+operator {
+  policy = "write"
+}
+
+
+namespace "*" {
+    policy = "write"
+    #capabilities = ["submit-job", "read-logs", "read-fs"]
 }


### PR DESCRIPTION
Permissions needed to perform certain other actions in the Nomad Cluster like. CSI plugin, submit jobs etc.