### PR TITLE
Update deployment to use the latest Ubuntu LTS Image

### DIFF
--- a/aws/image.pkr.hcl
+++ b/aws/image.pkr.hcl
@@ -1,3 +1,13 @@
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
+    }
+  }
+}
+
+
 locals { 
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
 }
@@ -10,7 +20,7 @@ data "amazon-ami" "hashistack" {
   filters = {
     architecture                       = "x86_64"
     "block-device-mapping.volume-type" = "gp2"
-    name                               = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
+    name                               = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
     root-device-type                   = "ebs"
     virtualization-type                = "hvm"
   }

--- a/azure/image.pkr.hcl
+++ b/azure/image.pkr.hcl
@@ -1,3 +1,12 @@
+packer {
+  required_plugins {
+    azure = {
+      source  = "github.com/hashicorp/azure"
+      version = "~> 2"
+    }
+  }
+}
+
 locals { 
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
 }
@@ -39,15 +48,15 @@ source "azure-arm" "hashistack" {
   tenant_id = var.tenant_id
   os_type = "Linux"
   image_publisher = "Canonical"
-  image_offer = "UbuntuServer"
-  image_sku = "16.04-LTS"
+  image_offer = "0001-com-ubuntu-server-jammy"
+  image_sku = "22_04-lts-gen2"
 
   azure_tags = {
     dept = "education"
   }
 
   location = var.location
-  vm_size = "Standard_A2"
+  vm_size = "Standard_B2s"
 }
 
 build {

--- a/gcp/image.pkr.hcl
+++ b/gcp/image.pkr.hcl
@@ -1,3 +1,12 @@
+packer {
+  required_plugins {
+    googlecompute = {
+      version = ">= 1.1.4"
+      source  = "github.com/hashicorp/googlecompute"
+    }
+  }
+}
+
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
 }
@@ -13,7 +22,7 @@ variable "zone" {
 source "googlecompute" "hashistack" {
   image_name   = "hashistack-${local.timestamp}"
   project_id   = var.project
-  source_image = "ubuntu-minimal-1804-bionic-v20221026"
+  source_image = "ubuntu-minimal-2204-jammy-v20231213b"
   ssh_username = "packer"
   zone         = var.zone
 }

--- a/shared/config/consul-systemd-resolved.conf
+++ b/shared/config/consul-systemd-resolved.conf
@@ -1,0 +1,5 @@
+[Resolve]
+DNS=127.0.0.1:8600
+DNSSEC=false
+Domains=~consul
+DNSStubListenerExtra=DOCKER_BRIDGE_IP_ADDRESS

--- a/shared/config/consul_aws.service
+++ b/shared/config/consul_aws.service
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 Restart=on-failure
 Environment=CONSUL_ALLOW_PRIVILEGED_PORTS=true
-ExecStart=/usr/local/bin/consul agent -config-dir="/etc/consul.d" -dns-port="53" -recursor="172.31.0.2"
+ExecStart=/usr/local/bin/consul agent -config-dir="/etc/consul.d" -recursor="172.31.0.2"
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM
 User=root

--- a/shared/config/consul_azure.service
+++ b/shared/config/consul_azure.service
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 Restart=on-failure
 Environment=CONSUL_ALLOW_PRIVILEGED_PORTS=true
-ExecStart=/usr/local/bin/consul agent -config-dir="/etc/consul.d" -dns-port="53" -recursor="172.31.0.2"
+ExecStart=/usr/local/bin/consul agent -config-dir="/etc/consul.d" -recursor="172.31.0.2"
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM
 User=root

--- a/shared/config/consul_gce.service
+++ b/shared/config/consul_gce.service
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 Restart=on-failure
 Environment=CONSUL_ALLOW_PRIVILEGED_PORTS=true
-ExecStart=/usr/local/bin/consul agent -config-dir="/etc/consul.d" -dns-port="8600" -recursor="172.31.0.2"
+ExecStart=/usr/local/bin/consul agent -config-dir="/etc/consul.d" -recursor="172.31.0.2"
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM
 User=root

--- a/shared/scripts/server.sh
+++ b/shared/scripts/server.sh
@@ -13,7 +13,7 @@ HOME_DIR=ubuntu
 # Wait for network
 sleep 15
 
-DOCKER_BRIDGE_IP_ADDRESS=(`ifconfig docker0 2>/dev/null|awk '/inet addr:/ {print $2}'|sed 's/addr://'`)
+DOCKER_BRIDGE_IP_ADDRESS=(`ip -brief addr show docker0 | awk '{print $3}' | awk -F/ '{print $1}'`)
 CLOUD=$1
 SERVER_COUNT=$2
 RETRY_JOIN=$3
@@ -86,11 +86,13 @@ sudo cp $CONFIGDIR/consul-template.service /etc/systemd/system/consul-template.s
 
 echo "127.0.0.1 $(hostname)" | sudo tee --append /etc/hosts
 
-# Add Docker bridge network IP to /etc/resolv.conf (at the top)
 
-echo "nameserver $DOCKER_BRIDGE_IP_ADDRESS" | sudo tee /etc/resolv.conf.new
-cat /etc/resolv.conf | sudo tee --append /etc/resolv.conf.new
-sudo mv /etc/resolv.conf.new /etc/resolv.conf
+# Add systemd-resolved configuration for Consul DNS
+# ref: https://developer.hashicorp.com/consul/tutorials/networking/dns-forwarding#systemd-resolved-setup
+sed -i "s/DOCKER_BRIDGE_IP_ADDRESS/$DOCKER_BRIDGE_IP_ADDRESS/g" $CONFIGDIR/consul-systemd-resolved.conf
+sudo mkdir -p /etc/systemd/resolved.conf.d/
+sudo cp $CONFIGDIR/consul-systemd-resolved.conf /etc/systemd/resolved.conf.d/consul.conf
+sudo systemctl restart systemd-resolved
 
 # Set env vars for tool CLIs
 echo "export CONSUL_RPC_ADDR=$IP_ADDRESS:8400" | sudo tee --append /home/$HOME_DIR/.bashrc

--- a/shared/scripts/setup.sh
+++ b/shared/scripts/setup.sh
@@ -48,7 +48,7 @@ case $CLOUD_ENV in
     ;;
 esac
 
-sudo apt-get update
+sudo add-apt-repository universe && sudo apt-get update
 sudo apt-get install -y unzip tree redis-tools jq curl tmux
 sudo apt-get clean
 

--- a/shared/scripts/setup.sh
+++ b/shared/scripts/setup.sh
@@ -36,7 +36,7 @@ case $CLOUD_ENV in
     ;;
 
   gce)
-    sudo apt-get update && sudo apt-get install -y software-properties-common
+    sudo apt-get clean && sudo apt-get update && sudo apt-get install -y software-properties-common
     ;;
 
   azure)


### PR DESCRIPTION
The Ubuntu Xenial image is not available anymore officially from Canonical on AWS (except the Pro versions).

The following changes were introduced as part of the AMI change:

* Switch to the latest LTS release (22.04/jammy)
* Switch to using the `ip` command instead of `ifconfig` (deprecated)
* Introduced a system-resolved drop-in for Consul DNS access and stopped Consul from listening on port 53. This is because systemd-resolved already binds to port 53, and Consul won't start.

  The drop-in configuration also listens on the Docker bridge IP so that Nomad tasks can resolve Consul DNS names by overriding DNS by pointing to the Docker bridge IP
* Explicitly added the universe repository without which `jq` and `redis-tools` installation were failing

In addition, `packer {}` block was added so that `packer init` installs the required plugins for the `build` to work.