### PR TITLE
Azure and GCP Update

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -7,7 +7,7 @@ data "aws_vpc" "default" {
 }
 
 resource "aws_security_group" "consul_nomad_ui_ingress" {
-  name   = "${var.name}-ui-ingress"
+  name   = "${var.name_prefix}-ui-ingress"
   vpc_id = data.aws_vpc.default.id
 
   # Nomad
@@ -42,7 +42,7 @@ resource "aws_security_group" "consul_nomad_ui_ingress" {
 }
 
 resource "aws_security_group" "ssh_ingress" {
-  name   = "${var.name}-ssh-ingress"
+  name   = "${var.name_prefix}-ssh-ingress"
   vpc_id = data.aws_vpc.default.id
 
   # SSH
@@ -69,7 +69,7 @@ resource "aws_security_group" "ssh_ingress" {
 }
 
 resource "aws_security_group" "allow_all_internal" {
-  name   = "${var.name}-allow-all-internal"
+  name   = "${var.name_prefix}-allow-all-internal"
   vpc_id = data.aws_vpc.default.id
 
   ingress {
@@ -88,7 +88,7 @@ resource "aws_security_group" "allow_all_internal" {
 }
 
 resource "aws_security_group" "clients_ingress" {
-  name   = "${var.name}-clients-ingress"
+  name   = "${var.name_prefix}-clients-ingress"
   vpc_id = data.aws_vpc.default.id
 
   ingress {
@@ -150,7 +150,7 @@ resource "aws_instance" "server" {
   # ConsulAutoJoin is necessary for nodes to automatically join the cluster
   tags = merge(
     {
-      "Name" = "${var.name}-server-${count.index}"
+      "Name" = "${var.name_prefix}-server-${count.index}"
     },
     {
       "ConsulAutoJoin" = "auto-join"
@@ -195,7 +195,7 @@ resource "aws_instance" "client" {
   # ConsulAutoJoin is necessary for nodes to automatically join the cluster
   tags = merge(
     {
-      "Name" = "${var.name}-client-${count.index}"
+      "Name" = "${var.name_prefix}-client-${count.index}"
     },
     {
       "ConsulAutoJoin" = "auto-join"
@@ -235,12 +235,12 @@ resource "aws_instance" "client" {
 }
 
 resource "aws_iam_instance_profile" "instance_profile" {
-  name_prefix = var.name
+  name_prefix = var.name_prefix
   role        = aws_iam_role.instance_role.name
 }
 
 resource "aws_iam_role" "instance_role" {
-  name_prefix        = var.name
+  name_prefix        = var.name_prefix
   assume_role_policy = data.aws_iam_policy_document.instance_role.json
 }
 
@@ -257,7 +257,7 @@ data "aws_iam_policy_document" "instance_role" {
 }
 
 resource "aws_iam_role_policy" "auto_discover_cluster" {
-  name   = "${var.name}-auto-discover-cluster"
+  name   = "${var.name_prefix}-auto-discover-cluster"
   role   = aws_iam_role.instance_role.id
   policy = data.aws_iam_policy_document.auto_discover_cluster.json
 }

--- a/aws/variables.hcl.example
+++ b/aws/variables.hcl.example
@@ -8,7 +8,7 @@ ami                       = "AMI_ID_FROM_PACKER_BUILD"
 # and do not need to be updated unless you want to
 # change them
 # allowlist_ip            = "0.0.0.0/0"
-# name                    = "nomad"
+# name_prefix             = "nomad"
 # server_instance_type    = "t2.micro"
 # server_count            = "3"
 # client_instance_type    = "t2.micro"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,4 +1,4 @@
-variable "name" {
+variable "name_prefix" {
   description = "Prefix used to name various infrastructure components. Alphanumeric characters only."
   default     = "nomad"
 }

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12"
   required_providers {

--- a/azure/image.pkr.hcl
+++ b/azure/image.pkr.hcl
@@ -17,6 +17,7 @@ variable "location" {
 
 variable "resource_group_name" {
   type = string
+  default = "hashistack"
 }
 
 source "azure-arm" "hashistack" {

--- a/azure/image.pkr.hcl
+++ b/azure/image.pkr.hcl
@@ -15,37 +15,14 @@ variable "location" {
   type = string
 }
 
-variable "client_id" {
-  type = string
-}
-
-variable "client_secret" {
-  type = string
-}
-
 variable "resource_group_name" {
   type = string
 }
 
-variable "storage_account" {
-  type = string
-}
-
-variable "subscription_id" {
-  type = string
-}
-
-variable "tenant_id" {
-  type = string
-}
-
 source "azure-arm" "hashistack" {
-  client_id = var.client_id
-  client_secret = var.client_secret
+  use_azure_cli_auth = true
   managed_image_resource_group_name = var.resource_group_name
   managed_image_name = "hashistack.${local.timestamp}"
-  subscription_id = var.subscription_id
-  tenant_id = var.tenant_id
   os_type = "Linux"
   image_publisher = "Canonical"
   image_offer = "0001-com-ubuntu-server-jammy"
@@ -69,6 +46,11 @@ build {
   provisioner "file" {
     destination = "/ops"
     source      = "../shared"
+  }
+
+  provisioner "shell" {
+    # workaround to cloud-init deleting apt lists while apt-update runs from setup.sh
+    inline = ["cloud-init status --wait"]
   }
 
   provisioner "shell" {

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -9,12 +9,9 @@ terraform {
 
 provider "azurerm" {
   features {}
-
-  subscription_id = var.subscription_id
-  client_id = var.client_id
-  client_secret = var.client_secret
-  tenant_id = var.tenant_id
 }
+
+data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "hashistack" {
   name     = "hashistack"
@@ -162,11 +159,7 @@ resource "azurerm_linux_virtual_machine" "server" {
   size                  = "${var.server_instance_type}"
   count                 = "${var.server_count}"
 
-  boot_diagnostics {
-    storage_account_uri = "https://${var.storage_account}.blob.core.windows.net/"
-  }
-
-  source_image_id = "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Compute/images/${var.image_name}"
+  source_image_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Compute/images/${var.image_name}"
 
   os_disk {
     name              = "hashistack-server-osdisk-${count.index}"
@@ -223,11 +216,7 @@ resource "azurerm_linux_virtual_machine" "client" {
   count                 = "${var.client_count}"
   depends_on            = [azurerm_linux_virtual_machine.server]
 
-  boot_diagnostics {
-    storage_account_uri = "https://${var.storage_account}.blob.core.windows.net/"
-  }
-
-  source_image_id = "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Compute/images/${var.image_name}"
+  source_image_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Compute/images/${var.image_name}"
 
   os_disk {
     name              = "hashistack-client-osdisk-${count.index}"

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -1,17 +1,36 @@
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "=3.0.0"
-    }
-  }
-}
-
-provider "azurerm" {
-  features {}
-}
-
 data "azurerm_client_config" "current" {}
+data "azuread_client_config" "current" {}
+
+resource "azurerm_role_assignment" "role_consul_autojoin" {
+  scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  role_definition_name = "Contributor"
+  principal_id         = "${azuread_service_principal.sp_consul.id}"
+}
+
+resource "azuread_application_registration" "app_consulautojoin" {
+  display_name = "consul-autojoin-authapp"
+}
+
+resource "azuread_application_password" "apppwd_consulautojoin" {
+  application_id = azuread_application_registration.app_consulautojoin.id
+}
+
+resource "azuread_service_principal" "sp_consul" {
+  client_id = azuread_application_registration.app_consulautojoin.client_id
+  owners = [ data.azuread_client_config.current.object_id ]
+}
+
+resource "random_uuid" "nomad_id" {
+}
+
+resource "random_uuid" "nomad_token" {
+}
+
+resource "random_string" "vm_password" {
+  length           = 16
+  special          = true
+  override_special = "/@£$"
+}
 
 resource "azurerm_resource_group" "hashistack" {
   name     = "hashistack"
@@ -169,15 +188,15 @@ resource "azurerm_linux_virtual_machine" "server" {
 
   computer_name  = "hashistack-server-${count.index}"
   admin_username = "ubuntu"
-  admin_password = var.admin_password
+  admin_password = random_string.vm_password.result
   custom_data    = "${base64encode(templatefile("${path.module}/../shared/data-scripts/user-data-server.sh", {
       region                    = var.location
       cloud_env                 = "azure"
       server_count              = "${var.server_count}"
-      retry_join                = var.retry_join
+      retry_join                = local.retry_join
       nomad_binary              = var.nomad_binary
-      nomad_consul_token_id     = var.nomad_consul_token_id
-      nomad_consul_token_secret = var.nomad_consul_token_secret
+      nomad_consul_token_id     = random_uuid.nomad_id.result
+      nomad_consul_token_secret = random_uuid.nomad_token.result
   }))}"
 
   disable_password_authentication = false
@@ -226,14 +245,18 @@ resource "azurerm_linux_virtual_machine" "client" {
 
   computer_name  = "hashistack-client-${count.index}"
   admin_username = "ubuntu"
-  admin_password = var.admin_password
+  admin_password = random_string.vm_password.result
   custom_data    = "${base64encode(templatefile("${path.module}/../shared/data-scripts/user-data-client.sh", {
       region                    = var.location
       cloud_env                 = "azure"
-      retry_join                = var.retry_join
+      retry_join                = local.retry_join
       nomad_binary              = var.nomad_binary
-      nomad_consul_token_secret = var.nomad_consul_token_secret
+      nomad_consul_token_secret = random_uuid.nomad_token.result
   }))}"
   
   disable_password_authentication = false
+}
+
+locals {
+  retry_join = "provider=azure tag_name=ConsulAutoJoin tag_value=auto-join subscription_id=${data.azurerm_client_config.current.subscription_id} tenant_id=${data.azurerm_client_config.current.tenant_id} client_id=${azuread_application_registration.app_consulautojoin.client_id} secret_access_key='${azuread_application_password.apppwd_consulautojoin.value}'"
 }

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -63,7 +63,7 @@ resource "azurerm_subnet_network_security_group_association" "hashistack-sg-asso
 }
 
 resource "azurerm_network_security_rule" "nomad_ui_ingress" {
-  name                        = "${var.name}-nomad-ui-ingress"
+  name                        = "${var.name_prefix}-nomad-ui-ingress"
   resource_group_name         = "${azurerm_resource_group.hashistack.name}"
   network_security_group_name = "${azurerm_network_security_group.hashistack-sg.name}"
 
@@ -79,7 +79,7 @@ resource "azurerm_network_security_rule" "nomad_ui_ingress" {
 }
 
 resource "azurerm_network_security_rule" "consul_ui_ingress" {
-  name                        = "${var.name}-consul-ui-ingress"
+  name                        = "${var.name_prefix}-consul-ui-ingress"
   resource_group_name         = "${azurerm_resource_group.hashistack.name}"
   network_security_group_name = "${azurerm_network_security_group.hashistack-sg.name}"
 
@@ -95,7 +95,7 @@ resource "azurerm_network_security_rule" "consul_ui_ingress" {
 }
 
 resource "azurerm_network_security_rule" "ssh_ingress" {
-  name                        = "${var.name}-ssh-ingress"
+  name                        = "${var.name_prefix}-ssh-ingress"
   resource_group_name         = "${azurerm_resource_group.hashistack.name}"
   network_security_group_name = "${azurerm_network_security_group.hashistack-sg.name}"
 
@@ -111,7 +111,7 @@ resource "azurerm_network_security_rule" "ssh_ingress" {
 }
 
 resource "azurerm_network_security_rule" "allow_all_internal" {
-  name                        = "${var.name}-allow-all-internal"
+  name                        = "${var.name_prefix}-allow-all-internal"
   resource_group_name         = "${azurerm_resource_group.hashistack.name}"
   network_security_group_name = "${azurerm_network_security_group.hashistack-sg.name}"
 
@@ -127,7 +127,7 @@ resource "azurerm_network_security_rule" "allow_all_internal" {
 }
 
 resource "azurerm_network_security_rule" "clients_ingress" {
-  name                        = "${var.name}-clients-ingress"
+  name                        = "${var.name_prefix}-clients-ingress"
   resource_group_name         = "${azurerm_resource_group.hashistack.name}"
   network_security_group_name = "${azurerm_network_security_group.hashistack-sg.name}"
 

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -1,9 +1,13 @@
+output "vm_password" {
+  value = random_string.vm_password.result
+}
+
 output "lb_address_consul_nomad" {
   value = "http://${azurerm_linux_virtual_machine.server[0].public_ip_address}"
 }
 
 output "consul_bootstrap_token_secret" {
-  value = var.nomad_consul_token_secret
+  value = random_uuid.nomad_token.result
 }
 
 output "IP_Addresses" {
@@ -14,6 +18,6 @@ Client public IPs: ${join(", ", azurerm_linux_virtual_machine.client[*].public_i
 Server public IPs: ${join(", ", azurerm_linux_virtual_machine.server[*].public_ip_address)}
 
 The Consul UI can be accessed at http://${azurerm_linux_virtual_machine.server[0].public_ip_address}:8500/ui
-with the bootstrap token: ${var.nomad_consul_token_secret}
+with the bootstrap token: ${random_uuid.nomad_token.result}
 CONFIGURATION
 }

--- a/azure/post-setup.sh
+++ b/azure/post-setup.sh
@@ -7,7 +7,7 @@ CONSUL_BOOTSTRAP_TOKEN=$(terraform output -raw consul_bootstrap_token_secret)
 # Get nomad user token from consul kv
 NOMAD_TOKEN=$(curl -s --header "Authorization: Bearer ${CONSUL_BOOTSTRAP_TOKEN}" "${LB_ADDRESS}:8500/v1/kv/nomad_user_token?raw")
 
-echo $NOMAD_TOKEN
+# echo $NOMAD_TOKEN
 
 # Save token to file if file doesn't already exist
 if [ ! -f $NOMAD_USER_TOKEN_FILENAME ]; then

--- a/azure/variables.hcl.example
+++ b/azure/variables.hcl.example
@@ -1,35 +1,16 @@
 # Packer variables (all are required)
-location = "LOCATION"
-subscription_id = "SUBSCRIPTION_ID"
-tenant_id = "TENANT_ID"
-client_id = "CLIENT_ID"
-client_secret = "CLIENT_SECRET"
-
-resource_group_name = "RESOURCE_GROUP_NAME"
-storage_account = "STORAGE_ACCOUNT_NAME"
-
-# Terraform variables (all are required)
-retry_join = "provider=azure tag_name=ConsulAutoJoin tag_value=auto-join subscription_id=SUBSCRIPTION_ID tenant_id=TENANT_ID client_id=CLIENT_ID secret_access_key=CLIENT_SECRET"
+location = "eastus"
+resource_group_name = "hashistack"
 
 # Alphanumeric and periods only
 image_name = "IMAGE_FROM_PACKER"
 
-nomad_consul_token_id = "123e4567-e89b-12d3-a456-426614174000"
-nomad_consul_token_secret = "123e4567-e89b-12d3-a456-426614174000"
-
-# Range to allow SSH and Consul/Nomad UI access
-# Ports 22, 8500, 4646
-# Default password for instances
-
 # These variables will default to the values shown
 # and do not need to be updated unless you want to
 # change them
-# admin_password                  = "password"
 # allowlist_ip                    = "0.0.0.0/0"
 # name                            = "nomad"
 # server_instance_type            = "t2.micro"
 # server_count                    = "3"
 # client_instance_type            = "t2.micro"
 # client_count                    = "3"
-
-

--- a/azure/variables.hcl.example
+++ b/azure/variables.hcl.example
@@ -19,13 +19,13 @@ nomad_consul_token_secret = "123e4567-e89b-12d3-a456-426614174000"
 
 # Range to allow SSH and Consul/Nomad UI access
 # Ports 22, 8500, 4646
-allowlist_ip = "0.0.0.0/0"
 # Default password for instances
-admin_password = "password"
 
 # These variables will default to the values shown
 # and do not need to be updated unless you want to
 # change them
+# admin_password                  = "password"
+# allowlist_ip                    = "0.0.0.0/0"
 # name                            = "nomad"
 # server_instance_type            = "t2.micro"
 # server_count                    = "3"

--- a/azure/variables.hcl.example
+++ b/azure/variables.hcl.example
@@ -9,7 +9,7 @@ image_name = "IMAGE_FROM_PACKER"
 # change them
 # resource_group_name             = "hashistack"
 # allowlist_ip                    = "0.0.0.0/0"
-# name                            = "nomad"
+# name_prefix             = "nomad"
 # server_instance_type            = "t2.micro"
 # server_count                    = "3"
 # client_instance_type            = "t2.micro"

--- a/azure/variables.hcl.example
+++ b/azure/variables.hcl.example
@@ -1,13 +1,13 @@
-# Packer variables (all are required)
+# Packer variables
 location = "eastus"
-resource_group_name = "hashistack"
 
-# Alphanumeric and periods only
+# Terraform variables
 image_name = "IMAGE_FROM_PACKER"
 
 # These variables will default to the values shown
 # and do not need to be updated unless you want to
 # change them
+# resource_group_name             = "hashistack"
 # allowlist_ip                    = "0.0.0.0/0"
 # name                            = "nomad"
 # server_instance_type            = "t2.micro"

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -1,4 +1,4 @@
-variable "name" {
+variable "name_prefix" {
   description = "Prefix used to name various infrastructure components. Alphanumeric characters only."
   default     = "nomad"
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -13,16 +13,7 @@ variable "image_name" {
 
 variable "resource_group_name" {
   description = "The Azure resource group name to use."
-}
-
-variable "admin_password" {
-  description = "The password for the ubuntu account on the server and client machines."
-  default     = "password"
-}
-
-variable "retry_join" {
-  description = "Used by Consul to automatically form a cluster."
-  type        = string
+  default     = "hashistack"
 }
 
 variable "allowlist_ip" {
@@ -48,19 +39,6 @@ variable "server_count" {
 variable "client_count" {
   description = "The number of clients to provision."
   default     = "3"
-}
-
-variable "root_block_device_size" {
-  description = "The volume size of the root block device."
-  default     = 16
-}
-
-variable "nomad_consul_token_id" {
-  description = "Accessor ID for the Consul ACL token used by Nomad servers and clients. Must be a UUID."
-}
-
-variable "nomad_consul_token_secret" {
-  description = "Secret ID for the Consul ACL token used by Nomad servers and clients. Must be a UUID."
 }
 
 variable "nomad_binary" {

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -11,32 +11,13 @@ variable "image_name" {
   description = "The Azure image to use for the server and client machines. Output from the Packer build process. This is the image NAME not the ID."
 }
 
-variable "subscription_id" {
-  description = "The Azure subscription ID to use."
-}
-
 variable "resource_group_name" {
   description = "The Azure resource group name to use."
 }
 
-variable "storage_account" {
-  description = "The storage account name. Used for boot diagnostics."
-}
-
-variable "client_id" {
-  description = "The Azure client ID to use."
-}
-
-variable "client_secret" {
-  description = "The Azure client secret to use."
-}
-
-variable "tenant_id" {
-  description = "The Azure tenant ID to use."
-}
-
 variable "admin_password" {
   description = "The password for the ubuntu account on the server and client machines."
+  default     = "password"
 }
 
 variable "retry_join" {

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12"
   required_providers {

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -1,4 +1,19 @@
 
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=3.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2"
+    }
+  }
+
+}
+
+provider "azurerm" {
+  features {}
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -5,11 +5,11 @@ provider "google" {
 }
 
 resource "google_compute_network" "hashistack" {
-  name = "hashistack-${var.name}"
+  name = "hashistack-${var.name_prefix}"
 }
 
 resource "google_compute_firewall" "consul_nomad_ui_ingress" {
-  name          = "${var.name}-ui-ingress"
+  name          = "${var.name_prefix}-ui-ingress"
   network       = google_compute_network.hashistack.name
   source_ranges = [var.allowlist_ip]
 
@@ -27,7 +27,7 @@ resource "google_compute_firewall" "consul_nomad_ui_ingress" {
 }
 
 resource "google_compute_firewall" "ssh_ingress" {
-  name          = "${var.name}-ssh-ingress"
+  name          = "${var.name_prefix}-ssh-ingress"
   network       = google_compute_network.hashistack.name
   source_ranges = [var.allowlist_ip]
 
@@ -39,7 +39,7 @@ resource "google_compute_firewall" "ssh_ingress" {
 }
 
 resource "google_compute_firewall" "allow_all_internal" {
-  name        = "${var.name}-allow-all-internal"
+  name        = "${var.name_prefix}-allow-all-internal"
   network     = google_compute_network.hashistack.name
   source_tags = ["auto-join"]
 
@@ -59,7 +59,7 @@ resource "google_compute_firewall" "allow_all_internal" {
 }
 
 resource "google_compute_firewall" "clients_ingress" {
-  name          = "${var.name}-clients-ingress"
+  name          = "${var.name_prefix}-clients-ingress"
   network       = google_compute_network.hashistack.name
   source_ranges = [var.allowlist_ip]
   target_tags   = ["nomad-clients"]
@@ -82,7 +82,7 @@ resource "random_uuid" "nomad_token" {
 
 resource "google_compute_instance" "server" {
   count        = var.server_count
-  name         = "${var.name}-server-${count.index}"
+  name         = "${var.name_prefix}-server-${count.index}"
   machine_type = var.server_instance_type
   zone         = var.zone
   tags         = ["auto-join"]
@@ -124,7 +124,7 @@ resource "google_compute_instance" "server" {
 
 resource "google_compute_instance" "client" {
   count        = var.client_count
-  name         = "${var.name}-client-${count.index}"
+  name         = "${var.name_prefix}-client-${count.index}"
   machine_type = var.client_instance_type
   zone         = var.zone
   tags         = ["auto-join", "nomad-clients"]

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -3,7 +3,7 @@ output "lb_address_consul_nomad" {
 }
 
 output "consul_bootstrap_token_secret" {
-  value = var.nomad_consul_token_secret
+  value = random_uuid.nomad_token.result
 }
 
 output "IP_Addresses" {
@@ -14,6 +14,6 @@ Client public IPs: ${join(", ", google_compute_instance.client[*].network_interf
 Server public IPs: ${join(", ", google_compute_instance.server[*].network_interface.0.access_config.0.nat_ip)}
 
 The Consul UI can be accessed at http://${google_compute_instance.server[0].network_interface.0.access_config.0.nat_ip}:8500/ui
-with the bootstrap token: ${var.nomad_consul_token_secret}
+with the bootstrap token: ${random_uuid.nomad_token.result}
 CONFIGURATION
 }

--- a/gcp/variables.hcl.example
+++ b/gcp/variables.hcl.example
@@ -10,7 +10,7 @@ machine_image             = "MACHINE_IMAGE_FROM_PACKER_BUILD"
 # and do not need to be updated unless you want to
 # change them
 # allowlist_ip            = "0.0.0.0/0"
-# name                    = "nomad"
+# name_prefix             = "nomad"
 # server_instance_type    = "t2.micro"
 # server_count            = "3"
 # client_instance_type    = "t2.micro"

--- a/gcp/variables.hcl.example
+++ b/gcp/variables.hcl.example
@@ -1,13 +1,10 @@
-# Packer variables (all are required)
+# Packer variables
 project                   = "GCP_PROJECT_ID"
 region                    = "GCP_REGION"
 zone                      = "GCP_ZONE"
 
-# Terraform variables (all are required)
-retry_join                = "project_name=GCP_PROJECT_ID zone_pattern=GCP_ZONE provider=gce tag_value=auto-join"
+# Terraform variables
 machine_image             = "MACHINE_IMAGE_FROM_PACKER_BUILD"
-nomad_consul_token_id     = "123e4567-e89b-12d3-a456-426614174000"
-nomad_consul_token_secret = "123e4567-e89b-12d3-a456-426614174000"
 
 # These variables will default to the values shown
 # and do not need to be updated unless you want to

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -14,7 +14,7 @@ variable "machine_image" {
   description = "The compute image to use for the server and client machines. Output from the Packer build process."
 }
 
-variable "name" {
+variable "name_prefix" {
   description = "Prefix used to name various infrastructure components. Alphanumeric characters only."
   default     = "nomad"
 }

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -19,11 +19,6 @@ variable "name" {
   default     = "nomad"
 }
 
-variable "retry_join" {
-  description = "Used by Consul to automatically form a cluster."
-  type        = string
-}
-
 variable "allowlist_ip" {
   description = "IP to allow access for the security groups (set 0.0.0.0/0 for world)"
   default     = "0.0.0.0/0"
@@ -52,14 +47,6 @@ variable "client_count" {
 variable "root_block_device_size" {
   description = "The volume size of the root block device."
   default     = 20
-}
-
-variable "nomad_consul_token_id" {
-  description = "Accessor ID for the Consul ACL token used by Nomad servers and clients. Must be a UUID."
-}
-
-variable "nomad_consul_token_secret" {
-  description = "Secret ID for the Consul ACL token used by Nomad servers and clients. Must be a UUID."
 }
 
 variable "nomad_binary" {

--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2"
+    }
+  }
 }


### PR DESCRIPTION
Changes:

- offload cloud authentication to user environment via the appropriate `az` or `gcloud` CLI tool
- rename variable NAME to name-prefix or something more descriptive
- autogenerate retry_join string from simple variables
- autogenerate UUIDs
- use a default resource group
- dynamic passwords for VMs
