### PR TITLE
Fix for 401 Unauthorized response from AWS metadata service

### DIFF
--- a/shared/scripts/client.sh
+++ b/shared/scripts/client.sh
@@ -21,7 +21,9 @@ NOMAD_BINARY=$3
 case $CLOUD in
   aws)
     echo "CLOUD_ENV: aws"
-    IP_ADDRESS=$(curl http://instance-data/latest/meta-data/local-ipv4)
+    TOKEN=$(curl -X PUT "http://instance-data/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+
+    IP_ADDRESS=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://instance-data/latest/meta-data/local-ipv4)
     ;;
   gce)
     echo "CLOUD_ENV: gce"

--- a/shared/scripts/server.sh
+++ b/shared/scripts/server.sh
@@ -23,7 +23,9 @@ NOMAD_BINARY=$4
 case $CLOUD in
   aws)
     echo "CLOUD_ENV: aws"
-    IP_ADDRESS=$(curl http://instance-data/latest/meta-data/local-ipv4)
+    TOKEN=$(curl -X PUT "http://instance-data/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+
+    IP_ADDRESS=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://instance-data/latest/meta-data/local-ipv4)
     ;;
   gce)
     echo "CLOUD_ENV: gce"


### PR DESCRIPTION
Fixes an issue with an unauthorized response from the AWS metadata service.
See [this PR](https://github.com/hashicorp-education/learn-nomad-getting-started/pull/12) for reference 