### PR TITLE
fix: update retry_join quoting to ensure variable expansion

### DIFF
--- a/shared/data-scripts/user-data-client.sh
+++ b/shared/data-scripts/user-data-client.sh
@@ -3,7 +3,7 @@
 set -e
 
 exec > >(sudo tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-sudo bash /ops/shared/scripts/client.sh "${cloud_env}" '${retry_join}' "${nomad_binary}"
+sudo bash /ops/shared/scripts/client.sh "${cloud_env}" "${retry_join}" "${nomad_binary}"
 
 NOMAD_HCL_PATH="/etc/nomad.d/nomad.hcl"
 CLOUD_ENV="${cloud_env}"

--- a/shared/data-scripts/user-data-server.sh
+++ b/shared/data-scripts/user-data-server.sh
@@ -3,7 +3,7 @@
 set -e
 
 exec > >(sudo tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
-sudo bash /ops/shared/scripts/server.sh "${cloud_env}" "${server_count}" '${retry_join}' "${nomad_binary}"
+sudo bash /ops/shared/scripts/server.sh "${cloud_env}" "${server_count}" "${retry_join}" "${nomad_binary}"
 
 ACL_DIRECTORY="/ops/shared/config"
 CONSUL_BOOTSTRAP_TOKEN="/tmp/consul_bootstrap"


### PR DESCRIPTION
This PR fixes the `retry_join` variable handling in the client setup script by changing it from single to double quotes. The `retry_join` value comes from a variable and needs to be expanded correctly by the shell.